### PR TITLE
投稿中の半角スペースを'+'と表示するバグを修正

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -37,7 +37,7 @@ function handle(req, res) {
       req.on('data', (chunk) => {
         body.push(chunk);
       }).on('end', () => {
-        body = Buffer.concat(body).toString();
+        body = Buffer.concat(body).toString().replace(/\+/g, '%20');
         const decoded = decodeURIComponent(body);
         const content = decoded.split('content=')[1];
         console.info('投稿されました: ' + content);


### PR DESCRIPTION
POSTの際のエンコーディングで半角スペースは'+'に変換されるが、decodeURIComponent関数は半角スペースは'%20'で表現されている前提でデコードするのがバグの原因である。そのためデコードの前に'+'を'%20'に置き換えることで対応。
参考：https://qiita.com/shibukawa/items/c0730092371c0e243f62